### PR TITLE
Don't accept menu touches when menu is hidden

### DIFF
--- a/LGPlusButtonsView/LGPlusButtonsView.m
+++ b/LGPlusButtonsView/LGPlusButtonsView.m
@@ -143,7 +143,7 @@ typedef NS_ENUM(NSUInteger, LGPlusButtonDescriptionsPosition)
 
         _contentView = [WrapperView new];
         _contentView.backgroundColor = [UIColor clearColor];
-        _contentView.userInteractionEnabled = YES;
+        _contentView.userInteractionEnabled = NO;
         [self addSubview:_contentView];
 
         _buttonsContentView = [WrapperView new];
@@ -1423,6 +1423,7 @@ typedef NS_ENUM(NSUInteger, LGPlusButtonDescriptionsPosition)
 
 - (void)showButtonsAnimated:(BOOL)animated completionHandler:(void(^)())completionHandler
 {
+    self.contentView.userInteractionEnabled = YES;
     if (self.isFirstButtonIsPlusButton)
     {
         LGPlusButton *plusButton = _buttonsArray[0];
@@ -1486,6 +1487,7 @@ typedef NS_ENUM(NSUInteger, LGPlusButtonDescriptionsPosition)
 
 - (void)hideButtonsAnimated:(BOOL)animated completionHandler:(void(^)())completionHandler
 {
+    self.contentView.userInteractionEnabled = NO;
     if (self.isFirstButtonIsPlusButton)
     {
         LGPlusButton *plusButton = _buttonsArray[0];


### PR DESCRIPTION
This fixes a rather annoying bug where a collapsed (hidden) menu still accepts touches (it's an edge case that I managed to trigger several times). This might not be the most elegant fix, but I just want to bring it to your attention.